### PR TITLE
feat: cooldown before next expedition

### DIFF
--- a/src/TwistedTaleweaver/Expeditions/Configurations/ExpeditionConfiguration.cs
+++ b/src/TwistedTaleweaver/Expeditions/Configurations/ExpeditionConfiguration.cs
@@ -1,8 +1,12 @@
 namespace TwistedTaleweaver.Expeditions.Configurations;
 
+using System.ComponentModel.DataAnnotations;
+
 public class ExpeditionConfiguration
 {
+    [Range(1, int.MaxValue, ErrorMessage = "TimeoutPeriodMinutes must be greater than 0")]
     public int TimeoutPeriodMinutes { get; set; }
     
+    [Range(1, int.MaxValue, ErrorMessage = "JoinPeriodMinutes must be greater than 0")]
     public int JoinPeriodMinutes { get; set; }
 }

--- a/src/TwistedTaleweaver/Expeditions/Configurations/ExpeditionConfiguration.cs
+++ b/src/TwistedTaleweaver/Expeditions/Configurations/ExpeditionConfiguration.cs
@@ -1,0 +1,8 @@
+namespace TwistedTaleweaver.Expeditions.Configurations;
+
+public class ExpeditionConfiguration
+{
+    public int TimeoutPeriodMinutes { get; set; }
+    
+    public int JoinPeriodMinutes { get; set; }
+}

--- a/src/TwistedTaleweaver/Expeditions/Facades/ExpeditionFacade.cs
+++ b/src/TwistedTaleweaver/Expeditions/Facades/ExpeditionFacade.cs
@@ -131,7 +131,7 @@ internal class ExpeditionFacade(
             return true;
         }
         
-        return (DateTimeOffset.Now - lastExpedition.CompletedAt.Value).TotalMinutes > _timeoutPeriodMinutes;
+        return (DateTimeOffset.UtcNow - lastExpedition.CompletedAt.Value).TotalMinutes > _timeoutPeriodMinutes;
     }
 
     public async Task JoinExpeditionAsync(string broadcasterExternalId, string userExternalId)

--- a/src/TwistedTaleweaver/Expeditions/Facades/ExpeditionFacade.cs
+++ b/src/TwistedTaleweaver/Expeditions/Facades/ExpeditionFacade.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Options;
 using Npgsql;
 using TwistedTaleweaver.Chat.Clients;
 using TwistedTaleweaver.Common;
@@ -12,6 +13,7 @@ using TwistedTaleweaver.DataAccess.Permissions.Entities.Enums;
 using TwistedTaleweaver.DataAccess.Permissions.Repositories;
 using TwistedTaleweaver.DataAccess.Streams.Repositories;
 using TwistedTaleweaver.DataAccess.Users.Repositories;
+using TwistedTaleweaver.Expeditions.Configurations;
 using TwistedTaleweaver.Expeditions.Entities.Inputs;
 using TwistedTaleweaver.Expeditions.Processors;
 using TwistedTaleweaver.Users.Clients;
@@ -46,10 +48,12 @@ internal class ExpeditionFacade(
     IUserApiClient userApiClient,
     IExpeditionCombatProcessor expeditionCombatProcessor,
     IExpeditionOutcomeRepository expeditionOutcomeRepository,
+    IOptions<ExpeditionConfiguration> configuration,
     Func<IUnitOfWork> createUnitOfWork,
     ILogger<ExpeditionFacade> logger) : IExpeditionFacade
 {
-    private static readonly TimeSpan JoinPeriod = TimeSpan.FromSeconds(15); //TimeSpan.FromMinutes(2);
+    private readonly TimeSpan _joinPeriod = TimeSpan.FromMinutes(configuration.Value.JoinPeriodMinutes);
+    private readonly int _timeoutPeriodMinutes = configuration.Value.TimeoutPeriodMinutes;
 
     public async Task StartExpeditionAsync(string broadcasterExternalId, string userExternalId)
     {
@@ -92,7 +96,19 @@ internal class ExpeditionFacade(
                 return;
             }
 
-            // TODO: Check if expedition cooldown passed
+            var lastExpedition = await expeditionRepository.GetLastExpeditionAsync(broadcaster.UserId, transaction);
+
+            if (!ExpeditionTimeoutHasPassed(lastExpedition))
+            {
+                logger.LogWarning(
+                    "Broadcaster {BroadcasterId} has an expedition timeout that has not passed when processing expedition creation command",
+                    broadcaster.UserId);
+                
+                await chatApiClient.SendChatMessageAsync(broadcaster.ExternalUserId,
+                    "The realm recoils from your last foray — patience, the next gate stirs slowly.");
+                
+                return;
+            }
 
             var expeditionId = await expeditionRepository.CreateExpeditionAsync(
                 activeStream.StreamId,
@@ -106,6 +122,16 @@ internal class ExpeditionFacade(
             await chatApiClient.SendChatMessageAsync(broadcaster.ExternalUserId,
                 "The ink is wet, the page awaits... I’ve summoned horrors untold. Who dares become part of this next tale?");
         });
+    }
+
+    private bool ExpeditionTimeoutHasPassed(Expedition? lastExpedition)
+    {
+        if (lastExpedition?.CompletedAt is null)
+        {
+            return true;
+        }
+        
+        return (DateTimeOffset.Now - lastExpedition.CompletedAt.Value).TotalMinutes > _timeoutPeriodMinutes;
     }
 
     public async Task JoinExpeditionAsync(string broadcasterExternalId, string userExternalId)
@@ -175,7 +201,7 @@ internal class ExpeditionFacade(
 
         await unitOfWork.ExecuteInTransactionAsync(async transaction =>
         {
-            var expeditionsToStart = await expeditionRepository.GetExpeditionsToStartAsync(JoinPeriod, transaction);
+            var expeditionsToStart = await expeditionRepository.GetExpeditionsToStartAsync(_joinPeriod, transaction);
             
             foreach (var expedition in expeditionsToStart)
             {

--- a/src/TwistedTaleweaver/Setup/ApplicationBuilderExtensions.cs
+++ b/src/TwistedTaleweaver/Setup/ApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using TwistedTaleweaver.Common;
+using TwistedTaleweaver.Expeditions.Configurations;
 using TwistedTaleweaver.Expeditions.Processors;
 using TwistedTaleweaver.Expeditions.Tasks;
 
@@ -11,6 +12,8 @@ public static class ApplicationBuilderExtensions
     {
         var assembly = Assembly.GetCallingAssembly();
 
+        builder.AddConfigurations();
+        
         return builder.Services
             .AddFacades(assembly)
             .AddApiClients(assembly)
@@ -63,5 +66,14 @@ public static class ApplicationBuilderExtensions
         services.AddHostedService<ExpeditionBackgroundService>();
         
         return services;
+    }
+
+    private static void AddConfigurations(this IHostApplicationBuilder builder)
+    {
+        builder.Services
+            .AddOptions<ExpeditionConfiguration>()
+            .Bind(builder.Configuration.GetSection("Expedition"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
     }
 }

--- a/src/TwistedTaleweaver/appsettings.json
+++ b/src/TwistedTaleweaver/appsettings.json
@@ -17,6 +17,10 @@
   "TwistedTaleweaver": {
     "BotUserId": "1336"
   },
+  "Expedition": {
+    "TimeoutPeriodMinutes": 10,
+    "JoinPeriodMinutes": 2
+  },
   "TwitchApi": {
     "HelixApiUrl": "https://api.twitch.tv/helix",
     "OAuthApiUrl": "https://id.twitch.tv",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced configurable expedition join and timeout periods, allowing customization of how long users can join expeditions and the cooldown between expeditions.
  * Added enforcement of a cooldown period before a new expedition can be started, with user feedback if the cooldown has not expired.
  * Enabled retrieval of the most recent expedition for broadcasters to support cooldown enforcement.

* **Chores**
  * Added new configuration options for expeditions in the settings, enabling easier adjustment of timing parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->